### PR TITLE
fix: Replacing postcss-nesting with postcss-nested plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const getSettings = function(options) {
     require('postcss-import')(),
 
     // allow nested rules
-    require('postcss-nesting')(),
+    require('postcss-nested')(),
 
     // allow custom properties, aka variables
     require('postcss-custom-properties')({preserve: false}),

--- a/package-lock.json
+++ b/package-lock.json
@@ -4728,12 +4728,30 @@
         }
       }
     },
-    "postcss-nesting": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-7.0.1.tgz",
-      "integrity": "sha512-FrorPb0H3nuVq0Sff7W2rnc3SmIcruVC6YwpcS+k687VxyxO33iE1amna7wHuRVzM8vfiYofXSBHNAZ3QhLvYg==",
+    "postcss-nested": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-5.0.1.tgz",
+      "integrity": "sha512-ZHNSAoHrMtbEzjq+Qs4R0gHijpXc6F1YUv4TGmGaz7rtfMvVJBbu5hMOH+CrhEaljQpEmx5N/P8i1pXTkbVAmg==",
       "requires": {
-        "postcss": "^7.0.2"
+        "postcss-selector-parser": "^6.0.4"
+      },
+      "dependencies": {
+        "cssesc": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+          "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
+        },
+        "postcss-selector-parser": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz",
+          "integrity": "sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==",
+          "requires": {
+            "cssesc": "^3.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1",
+            "util-deprecate": "^1.0.2"
+          }
+        }
       }
     },
     "postcss-progress": {
@@ -6060,8 +6078,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "postcss-csso": "^4.0.0",
     "postcss-custom-properties": "^9.0.2",
     "postcss-import": "^12.0.1",
-    "postcss-nesting": "^7.0.1",
+    "postcss-nested": "^5.0.1",
     "postcss-progress": "^1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This change will allow to unwrap nested rules like how Sass does it.