### PR TITLE
fix: Don't use banner option as browserslist arg

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const getSettings = function(options) {
 
   const settings = {
     banner: options.banner || `@name ${pkg.name} @version ${pkg.version} @license ${pkg.license}`,
-    browserslist: options.banner || pkg.browserslist || ['defaults', 'ie 11']
+    browserslist: options.browserslist || pkg.browserslist || ['defaults', 'ie 11']
   };
 
   settings.plugins = [


### PR DESCRIPTION
If a user tries to pass a `banner` option, whatever string is passed is also provided to browserslist and browserslist will error out because the banner string is not a valid query for browserslist, nor was this ever the intended function.  

This change will pass any option provided under the `browserslist` key of a passed options object, falling back (as before) to any option provided in `package.json` or defaults.

